### PR TITLE
Allow passing array of streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,13 @@ var duplexer = require('duplexer')
 var through = require('through')
 
 module.exports = function () {
-  var streams = [].slice.call(arguments)
+  var streams
+
+  if(arguments.length == 1 && Array.isArray(arguments[0])) {
+    streams = arguments[0]
+  } else {
+    streams = [].slice.call(arguments)
+  }
 
   if(streams.length == 0)
     return through()
@@ -19,17 +25,17 @@ module.exports = function () {
     if(streams.length < 2)
       return
     streams[0].pipe(streams[1])
-    recurse(streams.slice(1))  
+    recurse(streams.slice(1))
   }
-  
+
   recurse(streams)
- 
+
   function onerror () {
     var args = [].slice.call(arguments)
     args.unshift('error')
     thepipe.emit.apply(thepipe, args)
   }
-  
+
   //es.duplex already reemits the error from the first and last stream.
   //add a listener for the inner streams in the pipeline.
   for(var i = 1; i < streams.length - 1; i ++)
@@ -37,4 +43,3 @@ module.exports = function () {
 
   return thepipe
 }
-


### PR DESCRIPTION
This will let us passing the streams as arrays like;

``` js
var streams = [input, hasher]

if (true) streams.push(foobar)

streams.push(output)

combiner(streams)
```
