### PR TITLE
Rename onerror to fix conflict with gulp-plumber

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function () {
 
   recurse(streams)
 
-  function onerror () {
+  function errHandler () {
     var args = [].slice.call(arguments)
     args.unshift('error')
     thepipe.emit.apply(thepipe, args)
@@ -39,7 +39,7 @@ module.exports = function () {
   //es.duplex already reemits the error from the first and last stream.
   //add a listener for the inner streams in the pipeline.
   for(var i = 1; i < streams.length - 1; i ++)
-    streams[i].on('error', onerror)
+    streams[i].on('error', errHandler)
 
   return thepipe
 }


### PR DESCRIPTION
When used with `gulp-plumber`, 'error' events don't fire reliably, especially after a series of failing and successful stream inputs. I traced this down to the following:

'onerror' is the name of the default error handler for `readable-stream`.
`through2` uses `readable-stream`
`gulp-plumber` uses `through2`
`gulp-plumber` removes any listener called 'onerror' repeatedly to keep pipes working, causing some conflicts with this module.

This seemed like small change that doesn't cause much harm. I just changed the name of the 'onerror' function to 'errHandler'.

Thanks for the great work on this!
